### PR TITLE
docs(models): add JavaDoc comments to all model classes

### DIFF
--- a/payroll-module/src/main/java/com/app/payroll_service/models/Contract.java
+++ b/payroll-module/src/main/java/com/app/payroll_service/models/Contract.java
@@ -1,4 +1,5 @@
 package com.app.payroll_service.models;
+
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.time.LocalDateTime;
@@ -12,35 +13,62 @@ import lombok.Data;
 @Table(name = "contract")
 public class Contract {
 
+    /**
+     * Primary key for the contract table.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "contract_id", nullable = false)
     private Long contractId;
 
+    /**
+     * Reference to the associated work schedule.
+     */
     @ManyToOne
     @JoinColumn(name = "schedule_id", nullable = false)
     private Schedule schedule;
 
+    /**
+     * Reference to the type of contract.
+     */
     @ManyToOne
     @JoinColumn(name = "contract_type", nullable = false)
     private ContractType contractType;
 
+    /**
+     * Date when the contract started.
+     */
     @Column(name = "hire_date", nullable = false)
     private Date hireDate;
 
+    /**
+     * Date when the contract ended (nullable for ongoing contracts).
+     */
     @Column(name = "termination_date")
     private Date terminationDate;
 
+    /**
+     * Number of working hours per day defined in the contract.
+     */
     @Column(name = "daily_hours", nullable = false)
     private int dailyHours;
 
+    /**
+     * Monthly salary defined in the contract.
+     */
     @Column(name = "salary", nullable = false, precision = 10, scale = 2)
     private BigDecimal salary;
 
+    /**
+     * Timestamp when the contract record was created.
+     */
     @CreationTimestamp
     @Column(name = "created_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
+    /**
+     * Timestamp when the contract record was last updated.
+     */
     @UpdateTimestamp
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;

--- a/payroll-module/src/main/java/com/app/payroll_service/models/ContractType.java
+++ b/payroll-module/src/main/java/com/app/payroll_service/models/ContractType.java
@@ -2,12 +2,9 @@ package com.app.payroll_service.models;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -16,25 +13,45 @@ import lombok.*;
 @Table(name = "contract_type")
 public class ContractType {
 
+    /**
+     * Primary key for the contract_type table.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "contract_type_id", nullable = false)
     private Long contractTypeId;
 
+    /**
+     * List of contracts associated with this contract type.
+     * Marked with @JsonIgnore to avoid circular references during serialization.
+     */
     @OneToMany(mappedBy = "contractType", cascade = CascadeType.ALL)
     @JsonIgnore
     private List<Contract> contracts;
 
+    /**
+     * Name of the contract type.
+     */
     @Column(name = "name", nullable = false, length = 50)
     private String name;
 
+    /**
+     * Indicates if this contract type requires an end date.
+     * Stored in the database as TINYINT(1) (0 or 1).
+     */
     @Column(name = "requires_end_date", nullable = false, columnDefinition = "TINYINT(1)")
     private boolean requiresEndDate;
 
+    /**
+     * Timestamp when the contract type was created.
+     */
     @CreationTimestamp
     @Column(name = "created_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
+    /**
+     * Timestamp when the contract type was last updated.
+     */
     @UpdateTimestamp
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;

--- a/payroll-module/src/main/java/com/app/payroll_service/models/Deduction.java
+++ b/payroll-module/src/main/java/com/app/payroll_service/models/Deduction.java
@@ -3,12 +3,9 @@ package com.app.payroll_service.models;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
-
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -17,27 +14,46 @@ import lombok.Data;
 @Table(name = "deductions")
 public class Deduction {
 
+    /**
+     * Primary key for the deductions table.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "deduction_id", nullable = false)
     private Long deductionId;
 
+    /**
+     * Many-to-one relationship with the deduction type.
+     * Each deduction must be associated with one deduction type.
+     */
     @ManyToOne
     @JoinColumn(name = "deduction_type_id", nullable = false)
     private DeductionType deductionType;
 
+    /**
+     * The amount of the deduction.
+     */
     @Column(name = "amount", precision = 10, scale = 2, nullable = false)
     private BigDecimal amount;
 
-    // Relationship with payroll_deductions
+    /**
+     * One-to-many relationship with payroll deductions.
+     * This field is ignored in JSON serialization to prevent circular references.
+     */
     @OneToMany(mappedBy = "deduction", cascade = CascadeType.ALL)
     @JsonIgnore
     private List<PayrollDeductions> payrollDeductions;
 
+    /**
+     * Timestamp when the deduction was created.
+     */
     @CreationTimestamp
     @Column(name = "created_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
+    /**
+     * Timestamp when the deduction was last updated.
+     */
     @UpdateTimestamp
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;

--- a/payroll-module/src/main/java/com/app/payroll_service/models/DeductionType.java
+++ b/payroll-module/src/main/java/com/app/payroll_service/models/DeductionType.java
@@ -1,16 +1,12 @@
 package com.app.payroll_service.models;
 
 import jakarta.persistence.Entity;
-
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
-
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -19,26 +15,46 @@ import lombok.Data;
 @Table(name = "deduction_type")
 public class DeductionType {
 
+    /**
+     * Primary key for the deduction_type table.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "deduction_type_id", nullable = false)
     private Long deductionTypeId;
 
+    /**
+     * Name or description of the deduction type.
+     */
     @Column(name = "name", nullable = false)
     private String name;
 
+    /**
+     * One-to-many relationship with Deduction.
+     * A deduction type can be associated with multiple deductions.
+     * This field is ignored in JSON serialization to avoid recursion.
+     */
     @OneToMany(mappedBy = "deductionType", cascade = CascadeType.ALL)
     @JsonIgnore
     private List<Deduction> deductions;
 
-    // Percentage represented as a decimal. For example: 15% = 0.1500
+    /**
+     * Percentage applied to the deduction.
+     * Example: 15% should be stored as 0.1500
+     */
     @Column(name = "percentage", precision = 5, scale = 4, nullable = false)
     private BigDecimal percentage;
 
+    /**
+     * Timestamp of when the deduction type was created.
+     */
     @CreationTimestamp
     @Column(name = "created_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
+    /**
+     * Timestamp of the last update to the deduction type.
+     */
     @UpdateTimestamp
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;

--- a/payroll-module/src/main/java/com/app/payroll_service/models/License.java
+++ b/payroll-module/src/main/java/com/app/payroll_service/models/License.java
@@ -1,4 +1,5 @@
 package com.app.payroll_service.models;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.hibernate.annotations.CreationTimestamp;
@@ -11,36 +12,63 @@ import lombok.Data;
 @Table(name = "license")
 public class License {
 
+    /**
+     * Primary key for the license table.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "license_id", nullable = false)
     private Long licenseId;
 
+    /**
+     * Many-to-one relationship to the license type.
+     * Each license must be associated with a specific license type.
+     */
     @ManyToOne
     @JoinColumn(name = "license_type_id", nullable = false)
     private LicenseType licenseType;
 
+    /**
+     * ID of the user associated with this license.
+     */
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
+    /**
+     * Start date of the license period.
+     */
     @Column(name = "start_date", nullable = false)
     private LocalDate startDate;
 
+    /**
+     * End date of the license period.
+     */
     @Column(name = "end_date", nullable = false)
     private LocalDate endDate;
 
+    /**
+     * Total number of days covered by the license.
+     */
     @Column(name = "days", nullable = false)
     private int days;
 
+    /**
+     * Current status of the license (e.g., approved, pending, rejected).
+     */
     @Column(name = "status", nullable = false)
     private String status;
 
+    /**
+     * Timestamp of when the license was created.
+     */
     @CreationTimestamp
     @Column(name = "created_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
+    /**
+     * Timestamp of the last update made to the license.
+     */
     @UpdateTimestamp
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;
-
 }

--- a/payroll-module/src/main/java/com/app/payroll_service/models/LicenseType.java
+++ b/payroll-module/src/main/java/com/app/payroll_service/models/LicenseType.java
@@ -2,12 +2,9 @@ package com.app.payroll_service.models;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -16,27 +13,46 @@ import lombok.Data;
 @Table(name = "license_type")
 public class LicenseType {
 
+    /**
+     * Primary key for the license_type table.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "license_type_id", nullable = false)
     private Long licenseTypeId;
 
+    /**
+     * One-to-many relationship with License.
+     * A license type can be associated with multiple licenses.
+     */
     @OneToMany(mappedBy = "licenseType", cascade = CascadeType.ALL)
     @JsonIgnore
     private List<License> licenses;
 
+    /**
+     * Description of the license type (e.g., medical leave, vacation, etc.).
+     */
     @Column(name = "description", nullable = false)
     private String description;
 
+    /**
+     * Indicates if this license type should apply a salary discount.
+     * true (1) = discounted, false (0) = not discounted.
+     */
     @Column(name = "is_discount", nullable = false, columnDefinition = "TINYINT(1)")
     private boolean isDiscount;
 
+    /**
+     * Timestamp of when the license type record was created.
+     */
     @CreationTimestamp
     @Column(name = "created_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
+    /**
+     * Timestamp of the last update made to the license type.
+     */
     @UpdateTimestamp
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;
-
 }

--- a/payroll-module/src/main/java/com/app/payroll_service/models/Payroll.java
+++ b/payroll-module/src/main/java/com/app/payroll_service/models/Payroll.java
@@ -4,12 +4,9 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
-
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -18,39 +15,69 @@ import lombok.Data;
 @Table
 public class Payroll {
 
+    /**
+     * Primary key for the payroll table.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "payroll_id", nullable = false)
     private Long payrollId;
 
+    /**
+     * ID of the user (employee) associated with the payroll.
+     */
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
+    /**
+     * Number of days paid during the payroll period.
+     */
     @Column(name = "paid_days", nullable = false)
     private int paidDays;
 
+    /**
+     * Start date of the payroll period.
+     */
     @Column(name = "initial_period", nullable = false)
     private Date initialPeriod;
 
+    /**
+     * End date of the payroll period.
+     */
     @Column(name = "final_period", nullable = false)
     private Date finalPeriod;
 
+    /**
+     * Total net salary to be paid.
+     */
     @Column(name = "net_salary", nullable = false)
     private BigDecimal netSalary;
 
+    /**
+     * Status of the payroll (e.g., processed, pending, etc.).
+     */
     @Column(name = "status", nullable = false)
     private String status;
 
+    /**
+     * One-to-many relationship with PayrollDeductions.
+     * A payroll can have multiple deductions.
+     */
     @OneToMany(mappedBy = "payroll", cascade = CascadeType.ALL)
     @JsonIgnore
     private List<PayrollDeductions> payrollDeductions;
 
+    /**
+     * Timestamp of when the payroll record was created.
+     */
     @CreationTimestamp
     @Column(name = "created_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
+    /**
+     * Timestamp of the last update made to the payroll.
+     */
     @UpdateTimestamp
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;
-
 }

--- a/payroll-module/src/main/java/com/app/payroll_service/models/PayrollDeductions.java
+++ b/payroll-module/src/main/java/com/app/payroll_service/models/PayrollDeductions.java
@@ -1,14 +1,10 @@
 package com.app.payroll_service.models;
 
 import jakarta.persistence.Entity;
-
 import java.time.LocalDateTime;
-
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-
 import jakarta.persistence.*;
-import jakarta.persistence.Table;
 import lombok.Data;
 
 @Entity
@@ -16,25 +12,41 @@ import lombok.Data;
 @Table(name = "payroll_deductions")
 public class PayrollDeductions {
 
+    /**
+     * Primary key for the payroll_deductions table.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "payroll_deduction_id", nullable = false)
     private Long payrollDeductionId;
 
+    /**
+     * Many-to-one relationship to the Deduction entity.
+     * Each payroll deduction is linked to a specific deduction.
+     */
     @ManyToOne
     @JoinColumn(name = "deduction_id", nullable = false)
     private Deduction deduction;
 
+    /**
+     * Many-to-one relationship to the Payroll entity.
+     * Each payroll deduction is associated with a specific payroll.
+     */
     @ManyToOne
     @JoinColumn(name = "payroll_id", nullable = false)
     private Payroll payroll;
 
+    /**
+     * Timestamp of when the payroll deduction record was created.
+     */
     @CreationTimestamp
     @Column(name = "created_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
+    /**
+     * Timestamp of the last update made to the payroll deduction.
+     */
     @UpdateTimestamp
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;
-
 }

--- a/payroll-module/src/main/java/com/app/payroll_service/models/Schedule.java
+++ b/payroll-module/src/main/java/com/app/payroll_service/models/Schedule.java
@@ -1,10 +1,14 @@
 package com.app.payroll_service.models;
+
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -13,25 +17,44 @@ import lombok.Data;
 @Table(name = "schedule")
 public class Schedule {
 
+    /**
+     * Primary key for the schedule table.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "schedule_id", nullable = false)
     private Long scheduleId;
 
+    /**
+     * Time when the work schedule starts.
+     */
     @Column(name = "start_time", nullable = false)
     private LocalTime startTime;
-    
+
+    /**
+     * Time when the work schedule ends.
+     */
     @Column(name = "end_time", nullable = false)
     private LocalTime endTime;
-    
+
+    /**
+     * One-to-many relationship with Contract.
+     * A schedule can be associated with multiple contracts.
+     */
     @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL)
     @JsonIgnore
     private List<Contract> contracts;
-    
+
+    /**
+     * Timestamp of when the schedule record was created.
+     */
     @CreationTimestamp
     @Column(name = "created_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
+    /**
+     * Timestamp of the last update made to the schedule record.
+     */
     @UpdateTimestamp
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;

--- a/payroll-module/src/main/java/com/app/payroll_service/models/Vacation.java
+++ b/payroll-module/src/main/java/com/app/payroll_service/models/Vacation.java
@@ -1,4 +1,5 @@
 package com.app.payroll_service.models;
+
 import java.time.LocalDateTime;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -10,30 +11,54 @@ import jakarta.persistence.*;
 @Table(name = "vacation")
 public class Vacation {
 
+    /**
+     * Primary key for the vacation table.
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "vacation_id", nullable = false)
     private Long vacationId;
 
+    /**
+     * Identifier of the user who is taking the vacation.
+     */
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
+    /**
+     * Start date and time of the vacation period.
+     */
     @Column(name = "start_date", nullable = false)
     private LocalDateTime startDate;
 
+    /**
+     * End date and time of the vacation period.
+     */
     @Column(name = "end_date", nullable = false)
     private LocalDateTime endDate;
 
+    /**
+     * Number of vacation days taken.
+     */
     @Column(name = "taken_days", nullable = false)
     private int takenDays;
 
+    /**
+     * Current status of the vacation request (e.g., approved, pending, rejected).
+     */
     @Column(name = "status", nullable = false)
     private String status;
 
+    /**
+     * Timestamp indicating when the vacation record was created.
+     */
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    /**
+     * Timestamp indicating the last update to the vacation record.
+     */
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;


### PR DESCRIPTION
This commit adds detailed JavaDoc comments to all model classes in the payroll module to improve code documentation and maintainability. The comments describe the purpose of each field and its relationships, ensuring better understanding for developers working with the codebase.